### PR TITLE
Add light/dark `scheme-variant` support to builder.md

### DIFF
--- a/builder.md
+++ b/builder.md
@@ -1,5 +1,5 @@
 # Builder Guidelines
-**Version 0.10.1**
+**Version 0.11.0-dev**
 
 *The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD",
 "SHOULD NOT", "RECOMMENDED",  "MAY", and "OPTIONAL" in this document are to be
@@ -46,6 +46,7 @@ Scheme files have the following structure:
     scheme: "Scheme Name"
     author: "Scheme Author"
     description: "a short description of the scheme"
+    variant: "'light' or 'dark'"
     base00: "000000"
     base01: "111111"
     base02: "222222"
@@ -99,6 +100,8 @@ A builder MUST provide the following variables to template files:
 - `scheme-name` - obtained from the `scheme` key of the scheme file
 - `scheme-author` - obtained from the `author` key of the scheme file
 - `scheme-description` - obtained from the `description` key of the scheme file (fallback value: `scheme-name`)
+- `scheme-variant` - obtained from the `variant` key of the scheme file.
+- `is_{{variant}}_variant` - dynamic value obtained from the `variant` key of the scheme file. e.g. `variant: "light"` provides `is_light_variant` with a value of `true`. (fallback value: `is_dark_variant` with a value of `true`). Officially supported values are `light` and `dark`, but any string could theoretically be used.
 - `scheme-slug` - the scheme filename made lowercase, not including the `.yaml` extension
 - `base00-hex` to `base0F-hex` - 6-digit hex color value obtained from the scheme file. MUST NOT include a leading `#`. e.g "7cafc2".
 - `base00-hex-bgr` to `base0F-hex-bgr` - built from a reversed version of all the hex values e.g "c2af7c"


### PR DESCRIPTION
There are times when the generated colorschemes requires a dark/light variant, such as for VSCode: https://github.com/golf1052/base16-generator/blob/master/themes/base16-apathy-dark.json#L4. Until we add this support to the spec, vscode templates can't use any of our official builders.

`type` isn't an amazing property name, maybe `variant` would work better? My thought was to go for a string value instead of a boolean variant since one day we may have light, dark and medium for example :shrug: 

We'd have to add this field to each [scheme](https://github.com/base16-project/base16-schemes), but I could do that after we merge this. There may be several things I'm missing here, but I just wanted to get a PR out so we could discuss.